### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/src/js/libs/jquery.translate.js
+++ b/src/js/libs/jquery.translate.js
@@ -58,7 +58,7 @@
 					$this.attr(this.name, that.get(trn_attr_key));
 				}
 			});
-			$this.html(that.get(trn_key));
+			$this.html($("<div>").text(that.get(trn_key)).html());
 		});
 		return this;
 	};


### PR DESCRIPTION
Potential fix for [https://github.com/blackstarltd/pawnpaint/security/code-scanning/1](https://github.com/blackstarltd/pawnpaint/security/code-scanning/1)

To fix the issue, we need to ensure that any data inserted into the DOM via `$this.html()` is properly escaped to prevent XSS. This can be achieved by using a function to encode HTML entities, ensuring that any special characters (e.g., `<`, `>`, `&`, `"`), which could be interpreted as HTML or JavaScript, are safely displayed as plain text. The fix involves replacing the direct use of `that.get(trn_key)` with an escaped version of the returned value.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
